### PR TITLE
feat(ci): add Breaking Changes category

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"


### PR DESCRIPTION
# Pull Request

## Proposed Changes

### What

Add a new "💥 Breaking Changes" category to `.github/release-drafter.yaml`, ordered first so it sits above Features. The category collects PRs labeled `breaking`.

### Why

The `breaking` label already drives a major version bump via `version-resolver`, but breaking changes were silently bucketed under whatever other label the PR carried (feature, fix, etc.). Surfacing them as their own top-of-release section makes upgrade impact visible to consumers reading the changelog.

### Notes

- The `breaking` label is not in the `autolabeler` block — it must still be applied manually or via another automation.
- A PR carrying both `breaking` and `feature` labels will appear under Breaking Changes only (release-drafter places each PR in the first matching category).

## Testing

- Config-only change; effect will be visible in the next drafted release after a PR with the `breaking` label is merged.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request