### PR TITLE
fix(ci): order discussion after publish + auto-install syft for SBOMs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -290,9 +290,35 @@ jobs:
         run: |
           echo "::warning::Artifact attestation skipped — not available for private user-owned repositories. Make this repository public to enable attestation."
 
+  publish_release:
+    needs: [create_release, release_goreleaser, release_image]
+    if: >
+      always() &&
+      inputs.publish &&
+      needs.create_release.result == 'success' &&
+      (needs.release_goreleaser.result == 'success' || needs.release_goreleaser.result == 'skipped') &&
+      (needs.release_image.result == 'success' || needs.release_image.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Publish draft release
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Publish draft release
+        run: |
+          gh api \
+            --method PATCH \
+            "/repos/${{ github.repository }}/releases/${{ needs.create_release.outputs.release-id }}" \
+            -F draft=false
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+
   release_discussion:
-    needs: create_release
-    if: ${{ inputs.create-discussion && inputs.publish && needs.create_release.outputs.full-tag != '' }}
+    needs: [create_release, publish_release]
+    if: ${{ inputs.create-discussion && needs.publish_release.result == 'success' && needs.create_release.outputs.full-tag != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required by harden-runner
@@ -344,30 +370,3 @@ jobs:
           repository-id: ${{ env.DISCUSSION_REPOSITORY_ID }}
           category-id: ${{ env.DISCUSSION_CATEGORY_ID }}
           github-token: ${{ secrets.github-token }}
-
-  publish_release:
-    needs: [create_release, release_goreleaser, release_image, release_discussion]
-    if: >
-      always() &&
-      inputs.publish &&
-      needs.create_release.result == 'success' &&
-      (needs.release_goreleaser.result == 'success' || needs.release_goreleaser.result == 'skipped') &&
-      (needs.release_image.result == 'success' || needs.release_image.result == 'skipped') &&
-      (needs.release_discussion.result == 'success' || needs.release_discussion.result == 'skipped')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # Publish draft release
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
-
-      - name: Publish draft release
-        run: |
-          gh api \
-            --method PATCH \
-            "/repos/${{ github.repository }}/releases/${{ needs.create_release.outputs.release-id }}" \
-            -F draft=false
-        env:
-          GH_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,20 @@ jobs:
             exit 1
           fi
 
+      - name: Detect SBOM generation in GoReleaser config
+        id: detect-sbom
+        run: |
+          sboms=$(yq '.sboms // ""' "${{ inputs.goreleaser-config-path }}")
+          if [ -n "$sboms" ] && [ "$sboms" != "null" ]; then
+            echo "needs_syft=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_syft=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Syft for SBOM generation
+        if: steps.detect-sbom.outputs.needs_syft == 'true'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -179,7 +193,7 @@ jobs:
       - name: Upload artifacts to draft release
         run: |
           shopt -s nullglob
-          files=(dist/*.tar.gz dist/*.zip dist/checksums.txt)
+          files=(dist/*.tar.gz dist/*.zip dist/checksums.txt dist/*.spdx.json)
           if [ ${#files[@]} -eq 0 ]; then
             echo "::error::No artifacts found in dist/ to upload"
             exit 1
@@ -206,6 +220,7 @@ jobs:
             dist/*.tar.gz
             dist/*.zip
             dist/checksums.txt
+            dist/*.spdx.json
 
       - name: Skip attestation notice
         if: ${{ inputs.create-attestation && steps.repo-visibility.outputs.is_public != 'true' }}

--- a/.github/workflows/test-pr-title.yaml
+++ b/.github/workflows/test-pr-title.yaml
@@ -31,6 +31,8 @@ jobs:
         ci
         docs
         deps
+        github
+        release
       requireScope: false
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # Release Reusable Workflow
 
-Consolidated release workflow that creates a draft release, optionally builds artifacts (GoReleaser, Docker images), creates GitHub Discussions announcements, and publishes the release after all jobs succeed. This draft-first pattern supports repositories with immutable releases enabled.
+Consolidated release workflow that creates a draft release, optionally builds artifacts (GoReleaser, Docker images), publishes the release after all build jobs succeed, and then creates a GitHub Discussions announcement. This draft-first pattern supports repositories with immutable releases enabled and ensures announcements only fire for releases that publish successfully.
 
 ## Inputs
 
@@ -82,8 +82,8 @@ The workflow runs up to six jobs:
 1. **create_release** - Always runs. Creates a draft release via release-drafter, then creates and pushes the full and major version git tags.
 2. **release_goreleaser** - Runs when `goreleaser-config-path` is set. Builds Go binaries, uploads artifacts to the draft release, and optionally creates attestations.
 3. **release_image** - Runs when `image-name` is set. Builds and pushes a multi-platform Docker image, and optionally creates attestations.
-4. **release_discussion** - Runs when `create-discussion` is set. Both `discussion-category-id` and `discussion-repository-id` secrets are required if so. Creates a GitHub Discussions announcement.
-5. **publish_release** - Runs when `publish` is true and all preceding jobs succeed (or are skipped). Publishes the draft release.
+4. **publish_release** - Runs when `publish` is true and all preceding jobs succeed (or are skipped). Publishes the draft release.
+5. **release_discussion** - Runs after `publish_release` succeeds and when `create-discussion` is set. Both `discussion-category-id` and `discussion-repository-id` secrets are required if so. Creates a GitHub Discussions announcement only after the release is successfully published.
 
 ## GoReleaser Configuration
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -99,6 +99,10 @@ changelog:
 
 Without these settings, GoReleaser will attempt to create its own GitHub release, conflicting with the draft release created by release-drafter.
 
+### SBOM generation
+
+If your GoReleaser config includes an `sboms:` block that calls `syft`, the workflow detects it via `yq` and installs syft automatically before running GoReleaser. Generated `*.spdx.json` files are uploaded alongside the archives and included in the build provenance attestation when `create-attestation: true`. No additional configuration is needed beyond declaring `sboms:` in your GoReleaser config.
+
 ## Notes
 
 - The draft-first pattern supports repositories with **immutable releases** enabled. The release is created as a draft, artifacts are uploaded, and only then is it published.


### PR DESCRIPTION
## Proposed Changes

This PR bundles two release workflow fixes into a single change so consumers only need one SHA bump.

### 1. Move `release_discussion` to after `publish_release`

#### What

Move the `release_discussion` job to run after `publish_release` succeeds instead of in parallel with the build jobs. `publish_release` no longer depends on `release_discussion`.

#### Why

Previously, the announcement discussion was created before the draft release was published. If `publish_release` failed (or `publish` was disabled), subscribers were still notified about a release that did not actually exist as a published artifact. Gating discussion creation on a successful publish ensures announcements only fire for releases users can actually consume.

#### Notes

- The redundant `inputs.publish` check on `release_discussion` was removed; gating now flows through `publish_release`, which itself requires `inputs.publish`.
- Total wall-clock time for a full release increases slightly because the discussion job no longer runs in parallel with goreleaser/image builds — it now runs after publish.
- Behavior when `create-discussion` is false or discussion secrets are unset is unchanged.

### 2. Auto-install syft when GoReleaser config declares `sboms:`

#### What

In `release_goreleaser`, detect a `sboms:` block in the consumer's GoReleaser config (via the `yq` already installed for the existing `release.disable` check) and conditionally install `syft` before running GoReleaser. Generated `dist/*.spdx.json` files are now included in both the draft-release upload and the build provenance attestation subject paths.

#### Why

GoReleaser configs that declare `sboms.cmd: syft` previously failed inside the reusable workflow with `exec: "syft": executable file not found in $PATH`, because `release_goreleaser` did not install syft. A real example of the failure surfaced today on https://github.com/revanite-io/pvtr-gcp-cloud-storage/actions/runs/25644057576/job/75269470505 — the build hit syft missing in PATH, the release was left as a permanently-draft v0.1.2, and the consumer had to either drop SBOMs or maintain a separate workflow job (defeating the purpose of consolidating into this reusable workflow).

#### Notes

- The new `Install Syft for SBOM generation` step only runs when the config has an `sboms:` key, so consumers without SBOMs see no behavior change.
- syft is pinned via `anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0`. Happy to bump if a newer pin is preferred before merge.
- SBOM `.spdx.json` files are included in `attest-build-provenance` subject paths so attestation covers the same set of artifacts the user sees in the published release.

### Testing

- `actionlint .github/workflows/release.yaml` passes
- Manual review of the job graph: `create_release` → `[release_goreleaser, release_image]` → `publish_release` → `release_discussion`
- End-to-end verification will happen when this repo cuts its next release via `test-release.yaml`, and via the consumer repos that hit both bugs

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request