### PR TITLE
feat(release): add release-only-with-label input

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,11 @@ on:
         required: false
         type: string
         default: "go.mod"
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
     secrets:
       github-token:
         required: true
@@ -77,15 +82,19 @@ jobs:
   create_release:
     # Release if:
     # - Manual deployment (workflow_dispatch), OR
-    # - PR was merged with a breaking, feature, vuln, or release label
+    # - release-only-with-label is true and the PR has the 'release' label, OR
+    # - release-only-with-label is false (default) and the PR has a breaking, feature, vuln, or release label
     # Note: major/minor/patch labels alone do NOT trigger a release
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
-       (contains(github.event.pull_request.labels.*.name, 'breaking') ||
-        contains(github.event.pull_request.labels.*.name, 'feature') ||
-        contains(github.event.pull_request.labels.*.name, 'vuln') ||
-        contains(github.event.pull_request.labels.*.name, 'release')))
+       ((inputs.release-only-with-label &&
+         contains(github.event.pull_request.labels.*.name, 'release')) ||
+        (!inputs.release-only-with-label &&
+         (contains(github.event.pull_request.labels.*.name, 'breaking') ||
+          contains(github.event.pull_request.labels.*.name, 'feature') ||
+          contains(github.event.pull_request.labels.*.name, 'vuln') ||
+          contains(github.event.pull_request.labels.*.name, 'release')))))
     outputs:
       full-tag: ${{ steps.release-drafter.outputs.tag_name }}
       short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,22 +79,59 @@ on:
 permissions: {}
 
 jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by harden-runner
+    outputs:
+      should-release: ${{ steps.check.outputs.should-release }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Evaluate release conditions
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          RELEASE_ONLY: ${{ inputs.release-only-with-label }}
+        run: |
+          should_release=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch: releasing"
+            should_release=true
+          elif [ "$PR_MERGED" != "true" ]; then
+            echo "PR not merged: skipping release"
+          else
+            IFS=',' read -ra labels <<< "$PR_LABELS"
+            if [ "$RELEASE_ONLY" = "true" ]; then
+              for label in "${labels[@]}"; do
+                if [ "$label" = "release" ]; then
+                  should_release=true
+                  break
+                fi
+              done
+            else
+              for label in "${labels[@]}"; do
+                case "$label" in
+                  breaking|feature|vuln|release)
+                    should_release=true
+                    break
+                    ;;
+                esac
+              done
+            fi
+            echo "PR labels: ${PR_LABELS}, release-only-with-label: ${RELEASE_ONLY}, should-release: ${should_release}"
+          fi
+
+          echo "should-release=$should_release" >> "$GITHUB_OUTPUT"
+
   create_release:
-    # Release if:
-    # - Manual deployment (workflow_dispatch), OR
-    # - release-only-with-label is true and the PR has the 'release' label, OR
-    # - release-only-with-label is false (default) and the PR has a breaking, feature, vuln, or release label
-    # Note: major/minor/patch labels alone do NOT trigger a release
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       ((inputs.release-only-with-label &&
-         contains(github.event.pull_request.labels.*.name, 'release')) ||
-        (!inputs.release-only-with-label &&
-         (contains(github.event.pull_request.labels.*.name, 'breaking') ||
-          contains(github.event.pull_request.labels.*.name, 'feature') ||
-          contains(github.event.pull_request.labels.*.name, 'vuln') ||
-          contains(github.event.pull_request.labels.*.name, 'release')))))
+    needs: check_release
+    if: needs.check_release.outputs.should-release == 'true'
     outputs:
       full-tag: ${{ steps.release-drafter.outputs.tag_name }}
       short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,6 +27,9 @@ Consolidated release workflow that creates a draft release, optionally builds ar
     goreleaser-config-path: .goreleaser.yaml
     # Path to go.mod or go.work file for Go version detection, default is go.mod
     go-version-file: go.mod
+    # Only release when the 'release' label is on the PR. When true,
+    # other trigger labels (breaking, feature, vuln) are ignored. Default is false.
+    release-only-with-label: false
 
     # --- Optional: Docker image build/push ---
     # Setting image-name enables the image build/push job


### PR DESCRIPTION
## Proposed Changes

Add a `release-only-with-label` boolean input to the release workflow. When set to `true`, only the `release` label on a merged PR triggers a release, ignoring `breaking`, `feature`, and `vuln` as triggers. Defaults to `false` to preserve existing behavior.

Also extracts the release trigger logic from a nested GitHub Actions expression into a `check_release` gate job with a bash script. This is easier to read, debug via job logs, and extend as new options are added.

## What/Why

Gives consumers explicit control over when releases happen by requiring the `release` label, rather than having releases triggered implicitly by semantic labels like `breaking` or `feature`. The gate job refactor keeps the growing conditional maintainable.

## Proof it works

- `actionlint` and `shellcheck` both pass with no errors
- Default behavior (`false`) is unchanged -- existing label logic is preserved
- New path only activates when consumers explicitly opt in
- Downstream job dependency chain is unchanged (`check_release` -> `create_release` -> everything else)

## Risk + AI role

Low -- additive boolean input with a safe default and a pure refactor of existing logic. AI-assisted (Claude Opus 4.6).

## Review focus

The bash label-matching logic in `check_release` -- verify it matches the previous GitHub Actions expression semantics.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request