### PR TITLE
fix(release): use case-insensitive label matching in check_release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
           elif [ "$PR_MERGED" != "true" ]; then
             echo "PR not merged: skipping release"
           else
-            IFS=',' read -ra labels <<< "$PR_LABELS"
+            IFS=',' read -ra labels <<< "${PR_LABELS,,}"
             if [ "$RELEASE_ONLY" = "true" ]; then
               for label in "${labels[@]}"; do
                 if [ "$label" = "release" ]; then


### PR DESCRIPTION
## Proposed Changes

Lowercase PR labels before matching in the `check_release` gate job to preserve the case-insensitive behavior of the original GitHub Actions `contains()` expression replaced in #156.

## What/Why

The bash label check introduced in #156 compares case-sensitively, while the `contains()` it replaced was case-insensitive. A consumer with a capitalized label (e.g., `Release`) would silently stop getting releases.

## Proof it works

`actionlint` and `shellcheck` pass. The `${PR_LABELS,,}` bash 4+ expansion lowercases all label names before comparison.

## Risk + AI role

Low -- one-liner fix to a string comparison. AI-assisted (Claude Opus 4.6).

## Review focus

Confirm bash 4+ lowercase expansion (`${var,,}`) is available on the `ubuntu-latest` GitHub Actions runner.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request