### PR TITLE
fix(release): pin checkout ref to base repo to avoid v7 fork-PR refusal

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,6 +149,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Check out the base branch (merged code), not the fork PR head.
+          # Without an explicit ref, pull_request_target defaults to
+          # refs/pull/N/merge, which checkout v7 refuses as fork code.
+          ref: ${{ github.event.pull_request.base.ref || github.ref }}
           fetch-depth: 0
           persist-credentials: true # Required for git push of tags
       - name: Draft release
@@ -190,6 +194,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Build from the release tag, matching release_image. Avoids the
+          # checkout v7 fork-PR refusal under pull_request_target.
+          ref: ${{ needs.create_release.outputs.full-tag }}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
## Proposed Changes

`actions/checkout` v7.0.0 refuses to check out fork PR code under `pull_request_target` (the "pwn request" guard added in actions/checkout#2454). The `create_release` and `release_goreleaser` jobs leave `ref` unset, so under `pull_request_target` checkout defaults to `refs/pull/N/merge`. For any fork-originated PR this now fails with "Refusing to check out fork pull request code from a 'pull_request_target' workflow," which blocks the release entirely.

This pins both checkouts to base-repo refs so the guard is satisfied without opting into `allow-unsafe-pr-checkout` (that flag would suppress the guard while still pulling untrusted fork code, re-introducing the pwn-request exposure):

- `create_release`: `ref: ${{ github.event.pull_request.base.ref || github.ref }}` — checks out the merged base branch for PR-triggered runs, with a fallback for `workflow_dispatch`. Tags are pushed against the merge commit as before.
- `release_goreleaser`: `ref: ${{ needs.create_release.outputs.full-tag }}` — builds from the release tag, matching the existing `release_image` job.

`release_image` already pins `ref` to the tag, so it needs no change.

### Verification

Per `unsafe-pr-checkout-helper.ts`, the refusal fires only when the resolved ref matches `refs/pull/N/head|merge`; a base branch name or a release tag does not match, so the guard passes. `actionlint` and the repo's `pre-commit` hooks pass on the workflow.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request (no user-facing docs change needed)