### PR TITLE
fix(ci): run PR automation via pull_request_target for fork PRs

### DIFF
--- a/.github/workflows/auto-author-assign.yaml
+++ b/.github/workflows/auto-author-assign.yaml
@@ -1,7 +1,11 @@
 ---
 name: "Auto Author Assign"
+# Uses pull_request_target so the assign step gets a read-write token on fork
+# PRs (pull_request hands forks a read-only token, which makes the assignees
+# API call fail). Safe here: the workflow never checks out or executes PR-head
+# code, it only assigns the author via the API from the event payload.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 permissions:
   contents: read

--- a/.github/workflows/mark-ready-when-ready.yml
+++ b/.github/workflows/mark-ready-when-ready.yml
@@ -1,7 +1,13 @@
 name: Mark PR Ready When Ready
 
+# Uses pull_request_target so the mark-ready step gets a read-write token on
+# fork PRs (pull_request hands forks a read-only token, so contents: write is
+# denied and the job fails). Safe here: the workflow never checks out or
+# executes PR-head code. The action reads the PR number, draft flag, labels,
+# and head SHA from the event payload and acts only via the API, so running in
+# the base-repo context does not evaluate any untrusted code.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, labeled, unlabeled, synchronize]
 
 permissions:


### PR DESCRIPTION
## Proposed Changes

The `auto-author-assign` and `mark-ready-when-ready` workflows trigger on `pull_request`. For PRs from forks, GitHub caps the `GITHUB_TOKEN` at read-only regardless of the declared `permissions:` block, so both jobs fail:

- `auto-author-assign`: `Resource not accessible by integration` on the assignees API.
- `mark-ready-when-ready`: `Token is missing required permissions: contents: write`.

This switches both to `pull_request_target`, which runs in the base-repo context and receives a read-write token even for fork PRs.

This is safe because neither workflow checks out or executes PR-head code:

- `pull_request_target` runs the workflow definition from the base branch, so a fork PR cannot alter these workflows to abuse the elevated token.
- `toshimaru/auto-author-assign` assigns the author purely via the API from the event payload.
- `kenyonj/mark-ready-when-ready` reads the PR number, draft flag, labels, and `head.sha` from the event payload (verified it uses `github.event.pull_request.head.sha`, not `github.sha`) and acts only via `gh api`.

No checkout step exists in either workflow, so there is no untrusted code execution.

### Verification

`actionlint` and the repo's `pre-commit` hooks pass on both files.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request (no user-facing docs change needed)