### PR TITLE
feat(release): split release workflow into least-privilege variants

### DIFF
--- a/.github/workflows/release-container-attest.yaml
+++ b/.github/workflows/release-container-attest.yaml
@@ -1,0 +1,167 @@
+---
+name: "Release Container with Attestation"
+# Release variant: draft release + tags + Docker image build/push + build
+# provenance attestation + publish. Attestation is always on; it is skipped
+# automatically with a warning on private repositories where attestation is
+# not available.
+# Callers only need to grant:
+#   contents: write
+#   pull-requests: read
+#   packages: write
+#   id-token: write
+#   attestations: write
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish the release after all jobs complete. When false, the release remains a draft."
+        required: false
+        type: boolean
+        default: true
+      release-config-name:
+        required: true
+        type: string
+      image-name:
+        description: "Docker image name (e.g., owner/repo)."
+        required: true
+        type: string
+      image-registry:
+        description: "Container registry URL."
+        required: false
+        type: string
+        default: "ghcr.io"
+      image-registry-username:
+        description: "Container registry username."
+        required: false
+        type: string
+        default: ""
+      image-platforms:
+        description: "Comma-separated list of target platforms for Docker build."
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        required: true
+      image-registry-password:
+        required: true
+    outputs:
+      full-tag:
+        description: "Full tag of release"
+        value: ${{ jobs.draft.outputs.full-tag }}
+      short-tag:
+        description: "Short tag of release"
+        value: ${{ jobs.draft.outputs.short-tag }}
+      body:
+        description: "Body content of release"
+        value: ${{ jobs.draft.outputs.body }}
+      published:
+        description: "'true' when the release was published; empty when no release happened or publish is false"
+        value: ${{ jobs.publish.outputs.published }}
+
+permissions: {}
+
+jobs:
+  draft:
+    permissions:
+      contents: write # Create draft release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: ./.github/workflows/release-draft.yaml
+    with:
+      release-config-name: ${{ inputs.release-config-name }}
+      release-only-with-label: ${{ inputs.release-only-with-label }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  release_image:
+    needs: draft
+    if: ${{ needs.draft.outputs.full-tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
+      packages: write # Push container images
+      id-token: write # Federate via Workload Identity for attestation
+      attestations: write # Create build provenance attestation
+    env:
+      IMAGE_REGISTRY: ${{ inputs.image-registry }}
+      IMAGE_REGISTRY_USERNAME: ${{ inputs.image-registry-username || github.actor }}
+      IMAGE_REGISTRY_PASSWORD: ${{ secrets.image-registry-password }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Validate image registry password
+        if: ${{ env.IMAGE_REGISTRY_PASSWORD == '' }}
+        run: |
+          echo "::error::image-registry-password secret is required"
+          exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.draft.outputs.full-tag }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.IMAGE_REGISTRY_USERNAME }}
+          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
+
+      - name: Push Docker Image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        id: push
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:latest
+            ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:${{ needs.draft.outputs.full-tag }}
+            ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:${{ needs.draft.outputs.short-tag }}
+          platforms: ${{ inputs.image-platforms }}
+          provenance: false
+          sbom: false
+
+      - name: Check repository visibility
+        id: repo-visibility
+        run: |
+          visibility=$(gh api "repos/${{ github.repository }}" --jq '.visibility')
+          echo "is_public=$( [ "$visibility" = "public" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+
+      - name: Generate artifact attestation
+        if: ${{ steps.repo-visibility.outputs.is_public == 'true' }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+          github-token: ${{ secrets.github-token }}
+
+      - name: Skip attestation notice
+        if: ${{ steps.repo-visibility.outputs.is_public != 'true' }}
+        run: |
+          echo "::warning::Artifact attestation skipped — not available for private user-owned repositories. Make this repository public to enable attestation."
+
+  publish:
+    needs: [draft, release_image]
+    if: ${{ inputs.publish && needs.draft.outputs.release-id != '' }}
+    permissions:
+      contents: write # Publish draft release
+    uses: ./.github/workflows/release-publish.yaml
+    with:
+      release-id: ${{ needs.draft.outputs.release-id }}
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/.github/workflows/release-container-attest.yaml
+++ b/.github/workflows/release-container-attest.yaml
@@ -93,7 +93,7 @@ jobs:
       IMAGE_REGISTRY_PASSWORD: ${{ secrets.image-registry-password }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -136,14 +136,14 @@ jobs:
       - name: Check repository visibility
         id: repo-visibility
         run: |
-          visibility=$(gh api "repos/${{ github.repository }}" --jq '.visibility')
+          visibility=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility')
           echo "is_public=$( [ "$visibility" = "public" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.github-token }}
 
       - name: Generate artifact attestation
         if: ${{ steps.repo-visibility.outputs.is_public == 'true' }}
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -1,0 +1,140 @@
+---
+name: "Release Container"
+# Release variant: draft release + tags + Docker image build/push + publish.
+# No attestation; use release-container-attest.yaml for build provenance
+# attestations.
+# Callers only need to grant:
+#   contents: write
+#   pull-requests: read
+#   packages: write
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish the release after all jobs complete. When false, the release remains a draft."
+        required: false
+        type: boolean
+        default: true
+      release-config-name:
+        required: true
+        type: string
+      image-name:
+        description: "Docker image name (e.g., owner/repo)."
+        required: true
+        type: string
+      image-registry:
+        description: "Container registry URL."
+        required: false
+        type: string
+        default: "ghcr.io"
+      image-registry-username:
+        description: "Container registry username."
+        required: false
+        type: string
+        default: ""
+      image-platforms:
+        description: "Comma-separated list of target platforms for Docker build."
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        required: true
+      image-registry-password:
+        required: true
+    outputs:
+      full-tag:
+        description: "Full tag of release"
+        value: ${{ jobs.draft.outputs.full-tag }}
+      short-tag:
+        description: "Short tag of release"
+        value: ${{ jobs.draft.outputs.short-tag }}
+      body:
+        description: "Body content of release"
+        value: ${{ jobs.draft.outputs.body }}
+      published:
+        description: "'true' when the release was published; empty when no release happened or publish is false"
+        value: ${{ jobs.publish.outputs.published }}
+
+permissions: {}
+
+jobs:
+  draft:
+    permissions:
+      contents: write # Create draft release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: ./.github/workflows/release-draft.yaml
+    with:
+      release-config-name: ${{ inputs.release-config-name }}
+      release-only-with-label: ${{ inputs.release-only-with-label }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  release_image:
+    needs: draft
+    if: ${{ needs.draft.outputs.full-tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
+      packages: write # Push container images
+    env:
+      IMAGE_REGISTRY: ${{ inputs.image-registry }}
+      IMAGE_REGISTRY_USERNAME: ${{ inputs.image-registry-username || github.actor }}
+      IMAGE_REGISTRY_PASSWORD: ${{ secrets.image-registry-password }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Validate image registry password
+        if: ${{ env.IMAGE_REGISTRY_PASSWORD == '' }}
+        run: |
+          echo "::error::image-registry-password secret is required"
+          exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.draft.outputs.full-tag }}
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.IMAGE_REGISTRY_USERNAME }}
+          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
+
+      - name: Push Docker Image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        id: push
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:latest
+            ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:${{ needs.draft.outputs.full-tag }}
+            ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:${{ needs.draft.outputs.short-tag }}
+          platforms: ${{ inputs.image-platforms }}
+          provenance: false
+          sbom: false
+
+  publish:
+    needs: [draft, release_image]
+    if: ${{ inputs.publish && needs.draft.outputs.release-id != '' }}
+    permissions:
+      contents: write # Publish draft release
+    uses: ./.github/workflows/release-publish.yaml
+    with:
+      release-id: ${{ needs.draft.outputs.release-id }}
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -88,7 +88,7 @@ jobs:
       IMAGE_REGISTRY_PASSWORD: ${{ secrets.image-registry-password }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/release-discussion.yaml
+++ b/.github/workflows/release-discussion.yaml
@@ -1,12 +1,17 @@
 ---
-name: "Release Discussion (Deprecated)"
+name: "Release Discussion"
+# Chainable post-release workflow: creates a GitHub Discussions announcement
+# for a published release. Chain it after any release variant workflow using
+# that workflow's outputs, granting discussions: write only on this job.
 on:
   workflow_call:
     inputs:
       full-tag:
+        description: "Full tag of the release, used as the discussion title"
         required: true
         type: string
       body:
+        description: "Body content of the release, used as the discussion body"
         required: true
         type: string
     secrets:
@@ -20,13 +25,54 @@ on:
 permissions: {}
 
 jobs:
-  deprecated:
+  release_discussion:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read # Required by harden-runner
+      discussions: write # Create announcement discussions
+    env:
+      DISCUSSION_REPOSITORY_ID: ${{ secrets.discussion-repository-id }}
+      DISCUSSION_CATEGORY_ID: ${{ secrets.discussion-category-id }}
     steps:
-      - name: Deprecation notice
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Validate discussion prerequisites
+        id: check-inputs
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
         run: |
-          echo "::error::This workflow (release-discussion.yaml) has been deprecated and consolidated into release.yaml."
-          echo "::error::Migrate to the consolidated release workflow by setting the 'discussion-category-id' and 'discussion-repository-id' secrets on release.yaml instead."
-          echo "::error::See migration guide: https://github.com/github-community-projects/ospo-reusable-workflows/blob/main/docs/release-discussion.md"
-          exit 1
+          if [ -z "${DISCUSSION_REPOSITORY_ID}" ] || [ -z "${DISCUSSION_CATEGORY_ID}" ]; then
+            echo "::notice::discussion-repository-id and/or discussion-category-id secrets are not set, skipping discussion creation"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          has_discussions=$(gh api graphql -f query="
+            query(\$id: ID!) {
+              node(id: \$id) {
+                ... on Repository {
+                  hasDiscussionsEnabled
+                }
+              }
+            }
+          " -f id="${DISCUSSION_REPOSITORY_ID}" --jq '.data.node.hasDiscussionsEnabled')
+
+          if [ "$has_discussions" != "true" ]; then
+            echo "::notice::Discussions are not enabled on the target repository, skipping discussion creation"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create an Announcement Discussion for Release
+        if: ${{ steps.check-inputs.outputs.skip == 'false' }}
+        uses: abirismyname/create-discussion@c2b7c825241769dda523865ae444a879f6bbd0e0
+        with:
+          title: ${{ inputs.full-tag }}
+          body: ${{ inputs.body }}
+          repository-id: ${{ env.DISCUSSION_REPOSITORY_ID }}
+          category-id: ${{ env.DISCUSSION_CATEGORY_ID }}
+          github-token: ${{ secrets.github-token }}

--- a/.github/workflows/release-discussion.yaml
+++ b/.github/workflows/release-discussion.yaml
@@ -35,7 +35,7 @@ jobs:
       DISCUSSION_CATEGORY_ID: ${{ secrets.discussion-category-id }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -1,0 +1,137 @@
+---
+name: "Release Draft"
+# Building block: evaluates release conditions, creates a draft release via
+# release-drafter, and pushes the full and major version tags. Used by the
+# release variant workflows (release-minimal, release-goreleaser,
+# release-container) and callable directly for custom compositions. Pair with
+# release-publish.yaml to publish the draft after your build jobs complete.
+on:
+  workflow_call:
+    inputs:
+      release-config-name:
+        required: true
+        type: string
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        required: true
+    outputs:
+      should-release:
+        description: "Whether release conditions were met"
+        value: ${{ jobs.check_release.outputs.should-release }}
+      full-tag:
+        description: "Full tag of release"
+        value: ${{ jobs.create_release.outputs.full-tag }}
+      short-tag:
+        description: "Short tag of release"
+        value: ${{ jobs.create_release.outputs.short-tag }}
+      body:
+        description: "Body content of release"
+        value: ${{ jobs.create_release.outputs.body }}
+      release-id:
+        description: "ID of the draft release"
+        value: ${{ jobs.create_release.outputs.release-id }}
+
+permissions: {}
+
+jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by harden-runner
+    outputs:
+      should-release: ${{ steps.check.outputs.should-release }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Evaluate release conditions
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          RELEASE_ONLY: ${{ inputs.release-only-with-label }}
+        run: |
+          should_release=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch: releasing"
+            should_release=true
+          elif [ "$PR_MERGED" != "true" ]; then
+            echo "PR not merged: skipping release"
+          else
+            IFS=',' read -ra labels <<< "${PR_LABELS,,}"
+            if [ "$RELEASE_ONLY" = "true" ]; then
+              for label in "${labels[@]}"; do
+                if [ "$label" = "release" ]; then
+                  should_release=true
+                  break
+                fi
+              done
+            else
+              for label in "${labels[@]}"; do
+                case "$label" in
+                  breaking|feature|vuln|release)
+                    should_release=true
+                    break
+                    ;;
+                esac
+              done
+            fi
+            echo "PR labels: ${PR_LABELS}, release-only-with-label: ${RELEASE_ONLY}, should-release: ${should_release}"
+          fi
+
+          echo "should-release=$should_release" >> "$GITHUB_OUTPUT"
+
+  create_release:
+    needs: check_release
+    if: needs.check_release.outputs.should-release == 'true'
+    outputs:
+      full-tag: ${{ steps.release-drafter.outputs.tag_name }}
+      short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
+      body: ${{ steps.release-drafter.outputs.body }}
+      release-id: ${{ steps.release-drafter.outputs.id }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Create draft release via release-drafter
+      pull-requests: read # Read PR labels for release-drafter
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Check out the base branch tip, not the fork PR head. Without an
+          # explicit ref, pull_request_target defaults to refs/pull/N/merge,
+          # which checkout v7 refuses as fork code. Pinning to merge_commit_sha
+          # would also be refused (it is in the guard's blocklist), so the base
+          # branch is the guard-safe choice.
+          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: true # Required for git push of tags
+      - name: Draft release
+        id: release-drafter
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        with:
+          config-name: ${{ inputs.release-config-name }}
+          publish: false
+          token: ${{ secrets.github-token }}
+      - name: Get the Short Tag
+        id: get_tag_name
+        run: |
+          short_tag=$(echo "${{ steps.release-drafter.outputs.tag_name }}" | cut -d. -f1)
+          echo "SHORT_TAG=$short_tag" >> "$GITHUB_OUTPUT"
+      - name: Create and push tags
+        run: |
+          git tag -f "${{ steps.release-drafter.outputs.tag_name }}"
+          git tag -f "${{ steps.get_tag_name.outputs.SHORT_TAG }}" "${{ steps.release-drafter.outputs.tag_name }}"
+          git push -f origin "${{ steps.release-drafter.outputs.tag_name }}"
+          git push -f origin "${{ steps.get_tag_name.outputs.SHORT_TAG }}"

--- a/.github/workflows/release-draft.yaml
+++ b/.github/workflows/release-draft.yaml
@@ -47,7 +47,7 @@ jobs:
       should-release: ${{ steps.check.outputs.should-release }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Evaluate release conditions
@@ -103,7 +103,7 @@ jobs:
       pull-requests: read # Read PR labels for release-drafter
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout
@@ -126,12 +126,17 @@ jobs:
           token: ${{ secrets.github-token }}
       - name: Get the Short Tag
         id: get_tag_name
+        env:
+          FULL_TAG: ${{ steps.release-drafter.outputs.tag_name }}
         run: |
-          short_tag=$(echo "${{ steps.release-drafter.outputs.tag_name }}" | cut -d. -f1)
+          short_tag=$(echo "$FULL_TAG" | cut -d. -f1)
           echo "SHORT_TAG=$short_tag" >> "$GITHUB_OUTPUT"
       - name: Create and push tags
+        env:
+          FULL_TAG: ${{ steps.release-drafter.outputs.tag_name }}
+          SHORT_TAG: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
         run: |
-          git tag -f "${{ steps.release-drafter.outputs.tag_name }}"
-          git tag -f "${{ steps.get_tag_name.outputs.SHORT_TAG }}" "${{ steps.release-drafter.outputs.tag_name }}"
-          git push -f origin "${{ steps.release-drafter.outputs.tag_name }}"
-          git push -f origin "${{ steps.get_tag_name.outputs.SHORT_TAG }}"
+          git tag -f "$FULL_TAG"
+          git tag -f "$SHORT_TAG" "$FULL_TAG"
+          git push -f origin "$FULL_TAG"
+          git push -f origin "$SHORT_TAG"

--- a/.github/workflows/release-goreleaser-attest.yaml
+++ b/.github/workflows/release-goreleaser-attest.yaml
@@ -1,0 +1,240 @@
+---
+name: "Release GoReleaser with Attestation"
+# Release variant: draft release + tags + GoReleaser build/upload + build
+# provenance and SBOM (Software Bill of Materials) attestations + publish.
+# Attestation is always on; it is skipped automatically with a warning on
+# private repositories where attestation is not available.
+# Callers only need to grant:
+#   contents: write
+#   pull-requests: read
+#   id-token: write
+#   attestations: write
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish the release after all jobs complete. When false, the release remains a draft."
+        required: false
+        type: boolean
+        default: true
+      release-config-name:
+        required: true
+        type: string
+      goreleaser-config-path:
+        description: "Path to GoReleaser config file."
+        required: true
+        type: string
+      go-version-file:
+        description: "Path to go.mod or go.work file for Go version detection."
+        required: false
+        type: string
+        default: "go.mod"
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        required: true
+    outputs:
+      full-tag:
+        description: "Full tag of release"
+        value: ${{ jobs.draft.outputs.full-tag }}
+      short-tag:
+        description: "Short tag of release"
+        value: ${{ jobs.draft.outputs.short-tag }}
+      body:
+        description: "Body content of release"
+        value: ${{ jobs.draft.outputs.body }}
+      published:
+        description: "'true' when the release was published; empty when no release happened or publish is false"
+        value: ${{ jobs.publish.outputs.published }}
+
+permissions: {}
+
+jobs:
+  draft:
+    permissions:
+      contents: write # Create draft release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: ./.github/workflows/release-draft.yaml
+    with:
+      release-config-name: ${{ inputs.release-config-name }}
+      release-only-with-label: ${{ inputs.release-only-with-label }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  release_goreleaser:
+    needs: draft
+    if: ${{ needs.draft.outputs.full-tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Upload release assets
+      id-token: write # Federate for artifact attestation
+      attestations: write # Generate artifact attestations
+    outputs:
+      sbom_matrix: ${{ steps.sbom-matrix.outputs.matrix }}
+      is_public: ${{ steps.repo-visibility.outputs.is_public }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Build from the release tag. Avoids the checkout v7 fork-PR
+          # refusal under pull_request_target.
+          ref: ${{ needs.draft.outputs.full-tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install yq
+        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
+        with:
+          cmd: echo "yq installed"
+
+      - name: Validate GoReleaser config has release disabled
+        run: |
+          config="${{ inputs.goreleaser-config-path }}"
+          if ! [ -f "$config" ]; then
+            echo "::error::GoReleaser config file not found: $config"
+            exit 1
+          fi
+          release_disabled=$(yq '.release.disable' "$config")
+          if [ "$release_disabled" != "true" ]; then
+            echo "::error::GoReleaser config must have 'release: disable: true' to prevent conflicting with the draft release created by this workflow. See https://github.com/github-community-projects/ospo-reusable-workflows/blob/main/docs/release-goreleaser.md#goreleaser-configuration"
+            exit 1
+          fi
+
+      - name: Detect SBOM generation in GoReleaser config
+        id: detect-sbom
+        run: |
+          sboms=$(yq '.sboms // ""' "${{ inputs.goreleaser-config-path }}")
+          if [ -n "$sboms" ] && [ "$sboms" != "null" ]; then
+            echo "needs_syft=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_syft=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Syft for SBOM generation
+        if: steps.detect-sbom.outputs.needs_syft == 'true'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Build with GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --config ${{ inputs.goreleaser-config-path }}
+        env:
+          GORELEASER_CURRENT_TAG: ${{ needs.draft.outputs.full-tag }}
+
+      - name: Upload artifacts to draft release
+        run: |
+          shopt -s nullglob
+          files=(dist/*.tar.gz dist/*.zip dist/checksums.txt dist/*.spdx.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No artifacts found in dist/ to upload"
+            exit 1
+          fi
+          gh release upload "${{ needs.draft.outputs.full-tag }}" \
+            "${files[@]}" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+
+      - name: Check repository visibility
+        id: repo-visibility
+        run: |
+          visibility=$(gh api "repos/${{ github.repository }}" --jq '.visibility')
+          echo "is_public=$( [ "$visibility" = "public" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+
+      - name: Generate artifact attestation
+        if: ${{ steps.repo-visibility.outputs.is_public == 'true' }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
+            dist/*.spdx.json
+
+      - name: Skip attestation notice
+        if: ${{ steps.repo-visibility.outputs.is_public != 'true' }}
+        run: |
+          echo "::warning::Artifact attestation skipped — not available for private user-owned repositories. Make this repository public to enable attestation."
+
+      - name: Generate SBOM attestation matrix
+        id: sbom-matrix
+        if: ${{ steps.repo-visibility.outputs.is_public == 'true' }}
+        run: |
+          shopt -s nullglob
+          sboms=(dist/*.spdx.json)
+          if [ ${#sboms[@]} -eq 0 ]; then
+            echo "matrix=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          matrix=$(printf '%s\n' "${sboms[@]}" | jq -R '{"sbom": ., "archive": sub("\\.spdx\\.json$"; "")}' | jq -s -c '{"include": .}')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+      - name: Upload dist for SBOM attestation
+        if: ${{ steps.repo-visibility.outputs.is_public == 'true' && steps.sbom-matrix.outputs.matrix != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-dist
+          path: dist
+          retention-days: 1
+
+  attest_sboms:
+    needs: release_goreleaser
+    if: ${{ needs.release_goreleaser.outputs.is_public == 'true' && needs.release_goreleaser.outputs.sbom_matrix != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Federate for SBOM attestation
+      attestations: write # Generate SBOM attestations
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.release_goreleaser.outputs.sbom_matrix) }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-dist
+          path: dist
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: "${{ matrix.archive }}"
+          sbom-path: "${{ matrix.sbom }}"
+
+  publish:
+    needs: [draft, release_goreleaser, attest_sboms]
+    if: >
+      always() &&
+      inputs.publish &&
+      needs.draft.outputs.release-id != '' &&
+      needs.release_goreleaser.result == 'success' &&
+      (needs.attest_sboms.result == 'success' || needs.attest_sboms.result == 'skipped')
+    permissions:
+      contents: write # Publish draft release
+    uses: ./.github/workflows/release-publish.yaml
+    with:
+      release-id: ${{ needs.draft.outputs.release-id }}
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/.github/workflows/release-goreleaser-attest.yaml
+++ b/.github/workflows/release-goreleaser-attest.yaml
@@ -78,7 +78,7 @@ jobs:
       is_public: ${{ steps.repo-visibility.outputs.is_public }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -97,8 +97,10 @@ jobs:
           cmd: echo "yq installed"
 
       - name: Validate GoReleaser config has release disabled
+        env:
+          GORELEASER_CONFIG_PATH: ${{ inputs.goreleaser-config-path }}
         run: |
-          config="${{ inputs.goreleaser-config-path }}"
+          config="$GORELEASER_CONFIG_PATH"
           if ! [ -f "$config" ]; then
             echo "::error::GoReleaser config file not found: $config"
             exit 1
@@ -111,8 +113,10 @@ jobs:
 
       - name: Detect SBOM generation in GoReleaser config
         id: detect-sbom
+        env:
+          GORELEASER_CONFIG_PATH: ${{ inputs.goreleaser-config-path }}
         run: |
-          sboms=$(yq '.sboms // ""' "${{ inputs.goreleaser-config-path }}")
+          sboms=$(yq '.sboms // ""' "$GORELEASER_CONFIG_PATH")
           if [ -n "$sboms" ] && [ "$sboms" != "null" ]; then
             echo "needs_syft=true" >> "$GITHUB_OUTPUT"
           else
@@ -145,23 +149,24 @@ jobs:
             echo "::error::No artifacts found in dist/ to upload"
             exit 1
           fi
-          gh release upload "${{ needs.draft.outputs.full-tag }}" \
+          gh release upload "$FULL_TAG" \
             "${files[@]}" \
             --clobber
         env:
+          FULL_TAG: ${{ needs.draft.outputs.full-tag }}
           GH_TOKEN: ${{ secrets.github-token }}
 
       - name: Check repository visibility
         id: repo-visibility
         run: |
-          visibility=$(gh api "repos/${{ github.repository }}" --jq '.visibility')
+          visibility=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility')
           echo "is_public=$( [ "$visibility" = "public" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.github-token }}
 
       - name: Generate artifact attestation
         if: ${{ steps.repo-visibility.outputs.is_public == 'true' }}
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             dist/*.tar.gz
@@ -207,7 +212,7 @@ jobs:
       matrix: ${{ fromJson(needs.release_goreleaser.outputs.sbom_matrix) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/release-goreleaser.yaml
+++ b/.github/workflows/release-goreleaser.yaml
@@ -1,0 +1,155 @@
+---
+name: "Release GoReleaser"
+# Release variant: draft release + tags + GoReleaser build/upload + publish.
+# No attestation; use release-goreleaser-attest.yaml for build provenance
+# and SBOM (Software Bill of Materials) attestations.
+# Callers only need to grant:
+#   contents: write
+#   pull-requests: read
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish the release after all jobs complete. When false, the release remains a draft."
+        required: false
+        type: boolean
+        default: true
+      release-config-name:
+        required: true
+        type: string
+      goreleaser-config-path:
+        description: "Path to GoReleaser config file."
+        required: true
+        type: string
+      go-version-file:
+        description: "Path to go.mod or go.work file for Go version detection."
+        required: false
+        type: string
+        default: "go.mod"
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        required: true
+    outputs:
+      full-tag:
+        description: "Full tag of release"
+        value: ${{ jobs.draft.outputs.full-tag }}
+      short-tag:
+        description: "Short tag of release"
+        value: ${{ jobs.draft.outputs.short-tag }}
+      body:
+        description: "Body content of release"
+        value: ${{ jobs.draft.outputs.body }}
+      published:
+        description: "'true' when the release was published; empty when no release happened or publish is false"
+        value: ${{ jobs.publish.outputs.published }}
+
+permissions: {}
+
+jobs:
+  draft:
+    permissions:
+      contents: write # Create draft release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: ./.github/workflows/release-draft.yaml
+    with:
+      release-config-name: ${{ inputs.release-config-name }}
+      release-only-with-label: ${{ inputs.release-only-with-label }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  release_goreleaser:
+    needs: draft
+    if: ${{ needs.draft.outputs.full-tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Upload release assets
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Build from the release tag. Avoids the checkout v7 fork-PR
+          # refusal under pull_request_target.
+          ref: ${{ needs.draft.outputs.full-tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install yq
+        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
+        with:
+          cmd: echo "yq installed"
+
+      - name: Validate GoReleaser config has release disabled
+        run: |
+          config="${{ inputs.goreleaser-config-path }}"
+          if ! [ -f "$config" ]; then
+            echo "::error::GoReleaser config file not found: $config"
+            exit 1
+          fi
+          release_disabled=$(yq '.release.disable' "$config")
+          if [ "$release_disabled" != "true" ]; then
+            echo "::error::GoReleaser config must have 'release: disable: true' to prevent conflicting with the draft release created by this workflow. See https://github.com/github-community-projects/ospo-reusable-workflows/blob/main/docs/release-goreleaser.md#goreleaser-configuration"
+            exit 1
+          fi
+
+      - name: Detect SBOM generation in GoReleaser config
+        id: detect-sbom
+        run: |
+          sboms=$(yq '.sboms // ""' "${{ inputs.goreleaser-config-path }}")
+          if [ -n "$sboms" ] && [ "$sboms" != "null" ]; then
+            echo "needs_syft=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_syft=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Syft for SBOM generation
+        if: steps.detect-sbom.outputs.needs_syft == 'true'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Build with GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean --config ${{ inputs.goreleaser-config-path }}
+        env:
+          GORELEASER_CURRENT_TAG: ${{ needs.draft.outputs.full-tag }}
+
+      - name: Upload artifacts to draft release
+        run: |
+          shopt -s nullglob
+          files=(dist/*.tar.gz dist/*.zip dist/checksums.txt dist/*.spdx.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No artifacts found in dist/ to upload"
+            exit 1
+          fi
+          gh release upload "${{ needs.draft.outputs.full-tag }}" \
+            "${files[@]}" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+
+  publish:
+    needs: [draft, release_goreleaser]
+    if: ${{ inputs.publish && needs.draft.outputs.release-id != '' }}
+    permissions:
+      contents: write # Publish draft release
+    uses: ./.github/workflows/release-publish.yaml
+    with:
+      release-id: ${{ needs.draft.outputs.release-id }}
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/.github/workflows/release-goreleaser.yaml
+++ b/.github/workflows/release-goreleaser.yaml
@@ -70,7 +70,7 @@ jobs:
       contents: write # Upload release assets
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -89,8 +89,10 @@ jobs:
           cmd: echo "yq installed"
 
       - name: Validate GoReleaser config has release disabled
+        env:
+          GORELEASER_CONFIG_PATH: ${{ inputs.goreleaser-config-path }}
         run: |
-          config="${{ inputs.goreleaser-config-path }}"
+          config="$GORELEASER_CONFIG_PATH"
           if ! [ -f "$config" ]; then
             echo "::error::GoReleaser config file not found: $config"
             exit 1
@@ -103,8 +105,10 @@ jobs:
 
       - name: Detect SBOM generation in GoReleaser config
         id: detect-sbom
+        env:
+          GORELEASER_CONFIG_PATH: ${{ inputs.goreleaser-config-path }}
         run: |
-          sboms=$(yq '.sboms // ""' "${{ inputs.goreleaser-config-path }}")
+          sboms=$(yq '.sboms // ""' "$GORELEASER_CONFIG_PATH")
           if [ -n "$sboms" ] && [ "$sboms" != "null" ]; then
             echo "needs_syft=true" >> "$GITHUB_OUTPUT"
           else
@@ -137,10 +141,11 @@ jobs:
             echo "::error::No artifacts found in dist/ to upload"
             exit 1
           fi
-          gh release upload "${{ needs.draft.outputs.full-tag }}" \
+          gh release upload "$FULL_TAG" \
             "${files[@]}" \
             --clobber
         env:
+          FULL_TAG: ${{ needs.draft.outputs.full-tag }}
           GH_TOKEN: ${{ secrets.github-token }}
 
   publish:

--- a/.github/workflows/release-minimal.yaml
+++ b/.github/workflows/release-minimal.yaml
@@ -1,0 +1,63 @@
+---
+name: "Release Minimal"
+# Release variant: draft release + tags + publish. No artifact builds.
+# Callers only need to grant:
+#   contents: write
+#   pull-requests: read
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish the release after all jobs complete. When false, the release remains a draft."
+        required: false
+        type: boolean
+        default: true
+      release-config-name:
+        required: true
+        type: string
+      release-only-with-label:
+        description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github-token:
+        required: true
+    outputs:
+      full-tag:
+        description: "Full tag of release"
+        value: ${{ jobs.draft.outputs.full-tag }}
+      short-tag:
+        description: "Short tag of release"
+        value: ${{ jobs.draft.outputs.short-tag }}
+      body:
+        description: "Body content of release"
+        value: ${{ jobs.draft.outputs.body }}
+      published:
+        description: "'true' when the release was published; empty when no release happened or publish is false"
+        value: ${{ jobs.publish.outputs.published }}
+
+permissions: {}
+
+jobs:
+  draft:
+    permissions:
+      contents: write # Create draft release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: ./.github/workflows/release-draft.yaml
+    with:
+      release-config-name: ${{ inputs.release-config-name }}
+      release-only-with-label: ${{ inputs.release-only-with-label }}
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  publish:
+    needs: draft
+    if: ${{ inputs.publish && needs.draft.outputs.release-id != '' }}
+    permissions:
+      contents: write # Publish draft release
+    uses: ./.github/workflows/release-publish.yaml
+    with:
+      release-id: ${{ needs.draft.outputs.release-id }}
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,0 +1,47 @@
+---
+name: "Release Publish"
+# Building block: publishes a draft release created by release-draft.yaml.
+# Used by the release variant workflows and callable directly for custom
+# compositions. Call this after all build jobs that attach assets to the
+# draft release have completed, so repositories with immutable releases
+# enabled get a complete release at publish time.
+on:
+  workflow_call:
+    inputs:
+      release-id:
+        description: "ID of the draft release to publish, from release-draft.yaml"
+        required: true
+        type: string
+    secrets:
+      github-token:
+        required: true
+    outputs:
+      published:
+        description: "'true' when the draft release was published"
+        value: ${{ jobs.publish_release.outputs.published }}
+
+permissions: {}
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Publish draft release
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Publish draft release
+        id: publish
+        run: |
+          gh api \
+            --method PATCH \
+            "/repos/${{ github.repository }}/releases/${{ inputs.release-id }}" \
+            -F draft=false
+          echo "published=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -31,17 +31,22 @@ jobs:
       published: ${{ steps.publish.outputs.published }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
       - name: Publish draft release
         id: publish
+        env:
+          RELEASE_ID: ${{ inputs.release-id }}
+          GH_TOKEN: ${{ secrets.github-token }}
         run: |
+          if ! [[ "$RELEASE_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::release-id must be numeric, got: ${RELEASE_ID}"
+            exit 1
+          fi
           gh api \
             --method PATCH \
-            "/repos/${{ github.repository }}/releases/${{ inputs.release-id }}" \
+            "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
             -F draft=false
           echo "published=true" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.github-token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,15 +166,20 @@ jobs:
           token: ${{ secrets.github-token }}
       - name: Get the Short Tag
         id: get_tag_name
+        env:
+          FULL_TAG: ${{ steps.release-drafter.outputs.tag_name }}
         run: |
-          short_tag=$(echo "${{ steps.release-drafter.outputs.tag_name }}" | cut -d. -f1)
+          short_tag=$(echo "$FULL_TAG" | cut -d. -f1)
           echo "SHORT_TAG=$short_tag" >> "$GITHUB_OUTPUT"
       - name: Create and push tags
+        env:
+          FULL_TAG: ${{ steps.release-drafter.outputs.tag_name }}
+          SHORT_TAG: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
         run: |
-          git tag -f "${{ steps.release-drafter.outputs.tag_name }}"
-          git tag -f "${{ steps.get_tag_name.outputs.SHORT_TAG }}" "${{ steps.release-drafter.outputs.tag_name }}"
-          git push -f origin "${{ steps.release-drafter.outputs.tag_name }}"
-          git push -f origin "${{ steps.get_tag_name.outputs.SHORT_TAG }}"
+          git tag -f "$FULL_TAG"
+          git tag -f "$SHORT_TAG" "$FULL_TAG"
+          git push -f origin "$FULL_TAG"
+          git push -f origin "$SHORT_TAG"
 
   release_goreleaser:
     needs: create_release
@@ -208,8 +213,10 @@ jobs:
           cmd: echo "yq installed"
 
       - name: Validate GoReleaser config has release disabled
+        env:
+          GORELEASER_CONFIG_PATH: ${{ inputs.goreleaser-config-path }}
         run: |
-          config="${{ inputs.goreleaser-config-path }}"
+          config="$GORELEASER_CONFIG_PATH"
           if ! [ -f "$config" ]; then
             echo "::error::GoReleaser config file not found: $config"
             exit 1
@@ -222,8 +229,10 @@ jobs:
 
       - name: Detect SBOM generation in GoReleaser config
         id: detect-sbom
+        env:
+          GORELEASER_CONFIG_PATH: ${{ inputs.goreleaser-config-path }}
         run: |
-          sboms=$(yq '.sboms // ""' "${{ inputs.goreleaser-config-path }}")
+          sboms=$(yq '.sboms // ""' "$GORELEASER_CONFIG_PATH")
           if [ -n "$sboms" ] && [ "$sboms" != "null" ]; then
             echo "needs_syft=true" >> "$GITHUB_OUTPUT"
           else
@@ -256,16 +265,17 @@ jobs:
             echo "::error::No artifacts found in dist/ to upload"
             exit 1
           fi
-          gh release upload "${{ needs.create_release.outputs.full-tag }}" \
+          gh release upload "$FULL_TAG" \
             "${files[@]}" \
             --clobber
         env:
+          FULL_TAG: ${{ needs.create_release.outputs.full-tag }}
           GH_TOKEN: ${{ secrets.github-token }}
 
       - name: Check repository visibility
         id: repo-visibility
         run: |
-          visibility=$(gh api "repos/${{ github.repository }}" --jq '.visibility')
+          visibility=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility')
           echo "is_public=$( [ "$visibility" = "public" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.github-token }}
@@ -393,7 +403,7 @@ jobs:
         if: ${{ inputs.create-attestation }}
         id: repo-visibility
         run: |
-          visibility=$(gh api "repos/${{ github.repository }}" --jq '.visibility')
+          visibility=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.visibility')
           echo "is_public=$( [ "$visibility" = "public" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.github-token }}
@@ -431,13 +441,14 @@ jobs:
           egress-policy: audit
 
       - name: Publish draft release
+        env:
+          RELEASE_ID: ${{ needs.create_release.outputs.release-id }}
+          GH_TOKEN: ${{ secrets.github-token }}
         run: |
           gh api \
             --method PATCH \
-            "/repos/${{ github.repository }}/releases/${{ needs.create_release.outputs.release-id }}" \
+            "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
             -F draft=false
-        env:
-          GH_TOKEN: ${{ secrets.github-token }}
 
   release_discussion:
     needs: [create_release, publish_release]

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -14,15 +14,26 @@ jobs:
       packages: write # Push container images
       id-token: write # Federate via Workload Identity for attestation
       attestations: write # Create build provenance attestation
-      discussions: write # Create announcement discussions
-    uses: ./.github/workflows/release.yaml
+    uses: ./.github/workflows/release-container-attest.yaml
     with:
       publish: true
       release-config-name: release-drafter.yaml
       image-name: ${{ github.repository }}
-      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       image-registry-password: ${{ secrets.GITHUB_TOKEN }}
-      discussion-category-id: ${{ secrets.DISCUSSION_CATEGORY_ID }}
+
+  discussion:
+    needs: release
+    if: ${{ needs.release.outputs.published == 'true' }}
+    permissions:
+      contents: read # Required by harden-runner
+      discussions: write # Create announcement discussions
+    uses: ./.github/workflows/release-discussion.yaml
+    with:
+      full-tag: ${{ needs.release.outputs.full-tag }}
+      body: ${{ needs.release.outputs.body }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
       discussion-repository-id: ${{ secrets.DISCUSSION_REPOSITORY_ID }}
+      discussion-category-id: ${{ secrets.DISCUSSION_CATEGORY_ID }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Reusable Workflows
 
 > [!IMPORTANT]
-> The Release Image and Release Discussion workflows are now deprecated. The have been consolidated into the Release workflow.
+> The Release Image workflow is deprecated (consolidated into the Release workflow). The release workflow now comes in multiple variants so callers only grant the permissions they need — see [Choosing a variant](docs/release.md#choosing-a-variant).
 
 This is a placeholder repo for multiple GitHub Actions we use in open source projects.
 
@@ -11,9 +11,11 @@ This is a placeholder repo for multiple GitHub Actions we use in open source pro
 - [Labeler](docs/labeler.md)
 - [Major Version Updater](docs/major-version-updater.md)
 - [PR Title](docs/pr-title.md)
-- [Release](docs/release.md)
-- [Release Image](docs/release-image.md)
-- [Release Discussion](docs/release-discussion.md)
+- [Release](docs/release.md) (full, feature-flagged)
+- [Release Minimal](docs/release-minimal.md)
+- [Release GoReleaser](docs/release-goreleaser.md) (with and without attestation)
+- [Release Container](docs/release-container.md) (with and without attestation)
+- [Release Discussion](docs/release-discussion.md) (chainable announcement)
 
 > [!CAUTION]
 > Check the permissions in each reusable workflow to ensure the GitHub token you pass from your calling workflow meets the required permissions. Most of the time just passing `${{ secrets.GITHUB_TOKEN }}` is sufficient.

--- a/docs/release-container.md
+++ b/docs/release-container.md
@@ -1,0 +1,65 @@
+# Release Container Reusable Workflows
+
+Creates a draft release via release-drafter, pushes the full and major version git tags, builds and pushes a multi-platform Docker image tagged `latest`, the full tag, and the short tag, and publishes the release. The draft-first pattern supports repositories with **immutable releases** enabled.
+
+Two variants:
+
+- `release-container.yaml` - build and push only, no attestation
+- `release-container-attest.yaml` - additionally creates a build provenance attestation for the pushed image. Attestation is always on in this variant; it is skipped automatically with a warning on private repositories where attestation is not available.
+
+## Usage
+
+Without attestation:
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write # Create releases and push tags
+      pull-requests: read # Read PR labels for release-drafter
+      packages: write # Push container images
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-container.yaml@main
+    with:
+      # The name of the configuration file to use
+      # from the release-drafter/release-drafter GitHub Action
+      release-config-name: release-drafter.yml
+      # Image name, usually owner/repository (required)
+      image-name: ${{ github.repository }}
+      # Container registry URL, default is ghcr.io
+      image-registry: ghcr.io
+      # Container registry username, default is github.actor
+      image-registry-username: ${{ github.actor }}
+      # Comma-separated list of target platforms, default is linux/amd64,linux/arm64
+      image-platforms: linux/amd64,linux/arm64
+      # Publish the release after all jobs complete. Default is true.
+      publish: true
+      # Only release when the 'release' label is on the PR. Default is false.
+      release-only-with-label: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      # Container registry password (required)
+      image-registry-password: ${{ secrets.GITHUB_TOKEN }}
+```
+
+With attestation, use `release-container-attest.yaml` instead (same inputs and secrets) and grant two additional permissions:
+
+```yaml
+    permissions:
+      contents: write # Create releases and push tags
+      pull-requests: read # Read PR labels for release-drafter
+      packages: write # Push container images
+      id-token: write # Federate via Workload Identity for attestation
+      attestations: write # Create build provenance attestation
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-container-attest.yaml@main
+```
+
+## Outputs
+
+- full-tag: The full tag of the release (v1.0.0)
+- short-tag: The short tag of the release (v1)
+- body: The body of the release
+- published: 'true' when the release was published; empty when no release happened or publish is false
+
+## Announcement discussion
+
+To create a GitHub Discussions announcement after the release publishes, chain the [Release Discussion workflow](release-discussion.md) on this workflow's outputs.

--- a/docs/release-discussion.md
+++ b/docs/release-discussion.md
@@ -1,61 +1,61 @@
 # Release Discussion Reusable Workflow
 
-> [!CAUTION]
-> This workflow has been deprecated and consolidated into the [Release workflow](release.md). Calling `release-discussion.yaml` directly will fail with an error. Migrate by setting the `discussion-category-id` and `discussion-repository-id` secrets on `release.yaml` instead.
+Creates a GitHub Discussions announcement for a published release. Chain this workflow after any release variant workflow ([release-minimal](release-minimal.md), [release-goreleaser](release-goreleaser.md), [release-container](release-container.md)) using that workflow's outputs. This keeps `discussions: write` scoped to the discussion job only instead of forcing it on the whole release workflow.
 
-## Migration
+The consolidated [release.yaml](release.md) has discussion creation built in; use this workflow with the slimmer variants.
 
-Replace your existing `release-discussion.yaml` call:
-
-```yaml
-# Before (deprecated)
-release_discussion:
-  needs: release
-  uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-discussion.yaml@main
-  with:
-    full-tag: ${{ needs.release.outputs.full-tag }}
-    body: ${{ needs.release.outputs.body }}
-  secrets:
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-    discussion-repository-id: ${{ secrets.DISCUSSION_REPOSITORY_ID }}
-    discussion-category-id: ${{ secrets.DISCUSSION_CATEGORY_ID }}
-```
-
-With the consolidated `release.yaml` secrets:
+## Usage
 
 ```yaml
-# After
-release:
-  uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@main
-  with:
-    release-config-name: release-drafter.yaml
-  secrets:
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-    discussion-category-id: ${{ secrets.DISCUSSION_CATEGORY_ID }}
-    discussion-repository-id: ${{ secrets.DISCUSSION_REPOSITORY_ID }}
+jobs:
+  release:
+    permissions:
+      contents: write # Create releases and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-minimal.yaml@main
+    with:
+      release-config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  discussion:
+    needs: release
+    # Only announce when a release was actually published
+    if: ${{ needs.release.outputs.published == 'true' }}
+    permissions:
+      contents: read # Required by harden-runner
+      discussions: write # Create announcement discussions
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-discussion.yaml@main
+    with:
+      full-tag: ${{ needs.release.outputs.full-tag }}
+      body: ${{ needs.release.outputs.body }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      discussion-repository-id: ${{ secrets.DISCUSSION_REPOSITORY_ID }}
+      discussion-category-id: ${{ secrets.DISCUSSION_CATEGORY_ID }}
 ```
 
-Key changes:
-- `full-tag` and `body` no longer need to be passed — they are handled internally
-- Discussion IDs moved from required secrets to optional secrets
+The workflow skips gracefully (with a notice, not a failure) when the discussion IDs are empty or when Discussions are not enabled on the target repository.
 
-See the full [Release workflow documentation](release.md) for all available inputs.
+## Getting the discussion IDs
 
-## Notes
+Use the GitHub CLI (gh) with the following GraphQL query (replace `OWNER` and `REPO` with the appropriate values):
 
-To get the discussion repository ID and category ID, use the GitHub GraphQL API Explorer: https://docs.github.com/en/graphql/overview/explorer with the following query (replace `OWNER` and `REPO` with the appropriate values):
-
-```graphql
-query {
-  repository(owner: "OWNER", name: "REPO") {
-    id
-    discussionCategories(first: 50) {
-      nodes {
-        id
-        name
-        slug
+```
+gh api graphql -f query='
+  query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+      id
+      discussionCategories(first: 50) {
+        nodes {
+          id
+          name
+          slug
+        }
       }
     }
   }
-}
+' -f owner='OWNER' -f repo='REPO'
 ```
+
+Store the repository `id` as the `DISCUSSION_REPOSITORY_ID` secret and the chosen category `id` as the `DISCUSSION_CATEGORY_ID` secret.

--- a/docs/release-goreleaser.md
+++ b/docs/release-goreleaser.md
@@ -1,0 +1,77 @@
+# Release GoReleaser Reusable Workflows
+
+Creates a draft release via release-drafter, pushes the full and major version git tags, builds Go binaries with GoReleaser, uploads the artifacts to the draft release, and publishes the release. The draft-first pattern supports repositories with **immutable releases** enabled.
+
+Two variants:
+
+- `release-goreleaser.yaml` - build and upload only, no attestation
+- `release-goreleaser-attest.yaml` - additionally creates build provenance attestations for all artifacts and SBOM (Software Bill of Materials) attestations per archive. Attestation is always on in this variant; it is skipped automatically with a warning on private repositories where attestation is not available.
+
+## Usage
+
+Without attestation:
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write # Create releases, push tags, upload release assets
+      pull-requests: read # Read PR labels for release-drafter
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-goreleaser.yaml@main
+    with:
+      # The name of the configuration file to use
+      # from the release-drafter/release-drafter GitHub Action
+      release-config-name: release-drafter.yml
+      # Path to GoReleaser config file (required)
+      goreleaser-config-path: .goreleaser.yaml
+      # Path to go.mod or go.work file for Go version detection, default is go.mod
+      go-version-file: go.mod
+      # Publish the release after all jobs complete. Default is true.
+      publish: true
+      # Only release when the 'release' label is on the PR. Default is false.
+      release-only-with-label: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+With attestation, use `release-goreleaser-attest.yaml` instead (same inputs) and grant two additional permissions:
+
+```yaml
+    permissions:
+      contents: write # Create releases, push tags, upload release assets
+      pull-requests: read # Read PR labels for release-drafter
+      id-token: write # Federate for attestation
+      attestations: write # Generate artifact and SBOM attestations
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-goreleaser-attest.yaml@main
+```
+
+## Outputs
+
+- full-tag: The full tag of the release (v1.0.0)
+- short-tag: The short tag of the release (v1)
+- body: The body of the release
+- published: 'true' when the release was published; empty when no release happened or publish is false
+
+## GoReleaser configuration
+
+Your GoReleaser config **must** disable release and changelog management since this workflow handles both via release-drafter:
+
+```yaml
+release:
+  disable: true
+
+changelog:
+  disable: true
+```
+
+Without these settings, GoReleaser will attempt to create its own GitHub release, conflicting with the draft release created by release-drafter. The workflow validates this and fails early if release is not disabled.
+
+## SBOM generation
+
+If your GoReleaser config includes an `sboms:` block that calls `syft`, the workflow detects it via `yq` and installs syft automatically before running GoReleaser. Generated `*.spdx.json` files are uploaded alongside the archives.
+
+In the attest variant, the `attest_sboms` job additionally runs `actions/attest-sbom` per (archive, SBOM) pair. SBOM linkage requires GoReleaser to emit one SBOM per archive using the default `${artifact}.spdx.json` naming pattern (or any naming that strips `.spdx.json` to yield the matching archive path).
+
+## Announcement discussion
+
+To create a GitHub Discussions announcement after the release publishes, chain the [Release Discussion workflow](release-discussion.md) on this workflow's outputs.

--- a/docs/release-minimal.md
+++ b/docs/release-minimal.md
@@ -1,0 +1,44 @@
+# Release Minimal Reusable Workflow
+
+Creates a draft release via release-drafter, pushes the full and major version git tags, and publishes the release. No artifact builds. This is the right variant for repositories that only need release-drafter + tagging (for example, GitHub Action repositories).
+
+The draft-first pattern supports repositories with **immutable releases** enabled.
+
+## Usage
+
+```yaml
+jobs:
+  release:
+    permissions:
+      contents: write # Create releases and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-minimal.yaml@main
+    with:
+      # The name of the configuration file to use
+      # from the release-drafter/release-drafter GitHub Action
+      release-config-name: release-drafter.yml
+      # Publish the release after all jobs complete. When false, the release
+      # remains a draft for manual review. Default is true.
+      publish: true
+      # Only release when the 'release' label is on the PR. When true,
+      # other trigger labels (breaking, feature, vuln) are ignored. Default is false.
+      release-only-with-label: false
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Outputs
+
+- full-tag: The full tag of the release (v1.0.0)
+- short-tag: The short tag of the release (v1)
+- body: The body of the release
+- published: 'true' when the release was published; empty when no release happened or publish is false
+
+## Jobs
+
+1. **draft** - Evaluates release conditions, creates a draft release via release-drafter, and pushes the full and major version git tags (via [release-draft.yaml](../.github/workflows/release-draft.yaml)).
+2. **publish** - Publishes the draft release when `publish` is true (via [release-publish.yaml](../.github/workflows/release-publish.yaml)).
+
+## Announcement discussion
+
+To create a GitHub Discussions announcement after the release publishes, chain the [Release Discussion workflow](release-discussion.md) on this workflow's outputs.

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,22 @@
 
 Consolidated release workflow that creates a draft release, optionally builds artifacts (GoReleaser, Docker images), publishes the release after all build jobs succeed, and then creates a GitHub Discussions announcement. This draft-first pattern supports repositories with immutable releases enabled and ensures announcements only fire for releases that publish successfully.
 
+## Choosing a variant
+
+GitHub validates the permissions of every job in a called reusable workflow at parse time, before evaluating `if` conditions. Because this consolidated workflow bundles all optional jobs, callers must grant all six permission scopes even for features they do not use. If you only need some features, use one of the slimmer variant workflows instead:
+
+| Workflow | Features | Required permissions |
+| --- | --- | --- |
+| [release-minimal.yaml](release-minimal.md) | draft + tags + publish | `contents: write`, `pull-requests: read` |
+| [release-goreleaser.yaml](release-goreleaser.md) | minimal + Go binaries/SBOMs | `contents: write`, `pull-requests: read` |
+| [release-goreleaser-attest.yaml](release-goreleaser.md) | above + provenance/SBOM attestations | + `id-token: write`, `attestations: write` |
+| [release-container.yaml](release-container.md) | minimal + Docker image push | `contents: write`, `pull-requests: read`, `packages: write` |
+| [release-container-attest.yaml](release-container.md) | above + image attestation | + `id-token: write`, `attestations: write` |
+| [release-discussion.yaml](release-discussion.md) | chainable announcement discussion | `contents: read`, `discussions: write` (on that job only) |
+| release.yaml (this workflow) | everything, feature-flagged | all six scopes below |
+
+All variants share the same draft-first core: they create the draft release and tags, run their build jobs, and only then publish, so immutable releases stay supported. To announce releases from a variant, chain [release-discussion.yaml](release-discussion.md) on the variant's outputs.
+
 ## Inputs
 
 ```yaml
@@ -132,3 +148,50 @@ gh api graphql -f query='
   }
 ' -f owner='OWNER' -f repo='REPO'
 ```
+
+## Composing your own release workflow
+
+The variant workflows are thin compositions of two building blocks, which are also callable directly if no variant fits your needs:
+
+- [release-draft.yaml](../.github/workflows/release-draft.yaml) - evaluates release conditions (PR merged + trigger labels, or manual dispatch), creates the draft release via release-drafter, and pushes the full and major version tags. Outputs `should-release`, `full-tag`, `short-tag`, `body`, and `release-id`. Requires `contents: write`, `pull-requests: read`.
+- [release-publish.yaml](../.github/workflows/release-publish.yaml) - publishes the draft release by `release-id`. Requires `contents: write`.
+
+Put your own build jobs between them to attach assets to the draft before it publishes:
+
+```yaml
+jobs:
+  draft:
+    permissions:
+      contents: write # Create draft release and push tags
+      pull-requests: read # Read PR labels for release-drafter
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-draft.yaml@main
+    with:
+      release-config-name: release-drafter.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    needs: draft
+    if: ${{ needs.draft.outputs.full-tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Upload release assets
+    steps:
+      # ... build your artifacts, then:
+      - run: gh release upload "${{ needs.draft.outputs.full-tag }}" dist/*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: [draft, build]
+    if: ${{ needs.draft.outputs.release-id != '' }}
+    permissions:
+      contents: write # Publish draft release
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-publish.yaml@main
+    with:
+      release-id: ${{ needs.draft.outputs.release-id }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Reusable workflows can nest up to four levels deep. Calling a variant from your workflow uses three (your workflow, the variant, the building block), so you have one level to spare.


### PR DESCRIPTION
Closes #149

## What/Why

Callers of `release.yaml` are forced to grant all six permission scopes because GitHub validates nested job permissions at parse time, before `if` conditions are evaluated. This adds least-privilege release variants composed from shared building blocks, so callers only grant what they actually use:

| Workflow | Required permissions |
| --- | --- |
| `release-minimal.yaml` | `contents: write`, `pull-requests: read` |
| `release-goreleaser.yaml` | `contents: write`, `pull-requests: read` |
| `release-goreleaser-attest.yaml` | + `id-token: write`, `attestations: write` |
| `release-container.yaml` | + `packages: write` |
| `release-container-attest.yaml` | + `packages: write`, `id-token: write`, `attestations: write` |
| `release-discussion.yaml` (revived, chainable) | `contents: read`, `discussions: write` |

Each variant unconditionally nests new `release-draft.yaml` / `release-publish.yaml` building blocks (single source of truth, also callable directly for custom compositions), preserving the draft -> build -> publish ordering that supports immutable releases. `release.yaml` is unchanged for backwards compatibility, and `release-image.yaml` stays a deprecated stub. Variants expose a new `published` output so chained jobs (like the discussion announcement) only fire after a successful publish.

## Proof it works

- actionlint passes on all new and modified workflows.
- `test-release.yaml` now dogfoods `release-container-attest.yaml` plus the chained `release-discussion.yaml`, so this repository's own release exercises the new path (draft block, container build, attestation, publish block, discussion) on merge to main.

## Risk + AI role

medium -- switches this repository's own release path via `test-release.yaml`. Build/publish logic was extracted verbatim from `release.yaml` to minimize behavior drift. AI-generated with human-directed design decisions.

## Review focus

- Publish gating in each variant: skipped or failed build jobs must block publish, while `attest_sboms` may legitimately skip (private repo or no SBOMs).
- The `test-release.yaml` switch: the next merge to main releases via `release-container-attest.yaml` instead of `release.yaml`.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request