### PR TITLE
feat(release): image-dockerfile and image-build-args inputs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ on:
         type: string
         default: "./Dockerfile"
       image-build-args:
-        description: "Newline-separated list of build-time variables (passed through to docker/build-push-action build-args)."
+        description: "Newline-separated list of Docker build arguments in KEY=VALUE form (passed through to docker/build-push-action build-args). Do not pass secrets; build args can be exposed in build logs and image history."
         required: false
         type: string
         default: ""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,16 @@ on:
         required: false
         type: string
         default: "linux/amd64,linux/arm64"
+      image-dockerfile:
+        description: "Path to the Dockerfile."
+        required: false
+        type: string
+        default: "./Dockerfile"
+      image-build-args:
+        description: "Newline-separated list of build-time variables (passed through to docker/build-push-action build-args)."
+        required: false
+        type: string
+        default: ""
       goreleaser-config-path:
         description: "Path to GoReleaser config file. Enables GoReleaser build/upload when set."
         required: false
@@ -379,7 +389,8 @@ jobs:
         id: push
         with:
           context: .
-          file: ./Dockerfile
+          file: ${{ inputs.image-dockerfile }}
+          build-args: ${{ inputs.image-build-args }}
           push: true
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:latest

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,6 +41,13 @@ Consolidated release workflow that creates a draft release, optionally builds ar
     image-registry-username: ${{ github.actor }}
     # Comma-separated list of target platforms, default is linux/amd64,linux/arm64
     image-platforms: linux/amd64,linux/arm64
+    # Path to the Dockerfile, default is ./Dockerfile
+    image-dockerfile: ./Dockerfile
+    # Newline-separated build-time variables passed to the Docker build,
+    # default is none. Useful for baking build metadata into the image,
+    # e.g. the commit SHA.
+    image-build-args: |
+      GIT_COMMIT=${{ github.sha }}
     # Flag to create build provenance attestations, default is false
     # Attestation is only available for public repositories. Private repos
     # will see a warning and skip attestation automatically.

--- a/docs/release.md
+++ b/docs/release.md
@@ -43,9 +43,11 @@ Consolidated release workflow that creates a draft release, optionally builds ar
     image-platforms: linux/amd64,linux/arm64
     # Path to the Dockerfile, default is ./Dockerfile
     image-dockerfile: ./Dockerfile
-    # Newline-separated build-time variables passed to the Docker build,
-    # default is none. Useful for baking build metadata into the image,
-    # e.g. the commit SHA.
+    # Newline-separated Docker build arguments in KEY=VALUE form, passed
+    # to the Docker build via docker/build-push-action build-args.
+    # Default is none. Useful for baking build metadata into the image,
+    # e.g. the commit SHA. Do not use build args for secrets; they can be
+    # exposed in build logs and image history.
     image-build-args: |
       GIT_COMMIT=${{ github.sha }}
     # Flag to create build provenance attestations, default is false


### PR DESCRIPTION
## Proposed Changes

The `release_image` job hardcodes `file: ./Dockerfile` and passes no build arguments, so callers cannot build from a non-root Dockerfile or bake build-time metadata (e.g. the release commit SHA) into the image. Downstream repos that previously passed `build-args` through their own `docker/build-push-action` workflow lose that capability when migrating to this reusable.

This adds two optional passthrough inputs, both defaulting to current behavior (non-breaking):

- `image-dockerfile` — path to the Dockerfile (default `./Dockerfile`)
- `image-build-args` — newline-separated build-time variables forwarded to `docker/build-push-action`'s `build-args` (default none)

Documented in `docs/release.md` with a `GIT_COMMIT` example. `actionlint` passes.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request