### PR TITLE
feat(release): add image-dockerfile and image-build-args to container variants

### DIFF
--- a/.github/workflows/release-container-attest.yaml
+++ b/.github/workflows/release-container-attest.yaml
@@ -40,6 +40,16 @@ on:
         required: false
         type: string
         default: "linux/amd64,linux/arm64"
+      image-dockerfile:
+        description: "Path to the Dockerfile."
+        required: false
+        type: string
+        default: "./Dockerfile"
+      image-build-args:
+        description: "Newline-separated list of Docker build arguments in KEY=VALUE form (passed through to docker/build-push-action build-args). Do not pass secrets; build args can be exposed in build logs and image history."
+        required: false
+        type: string
+        default: ""
       release-only-with-label:
         description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
         required: false
@@ -123,7 +133,8 @@ jobs:
         id: push
         with:
           context: .
-          file: ./Dockerfile
+          file: ${{ inputs.image-dockerfile }}
+          build-args: ${{ inputs.image-build-args }}
           push: true
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:latest

--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -37,6 +37,16 @@ on:
         required: false
         type: string
         default: "linux/amd64,linux/arm64"
+      image-dockerfile:
+        description: "Path to the Dockerfile."
+        required: false
+        type: string
+        default: "./Dockerfile"
+      image-build-args:
+        description: "Newline-separated list of Docker build arguments in KEY=VALUE form (passed through to docker/build-push-action build-args). Do not pass secrets; build args can be exposed in build logs and image history."
+        required: false
+        type: string
+        default: ""
       release-only-with-label:
         description: "Only create a release when the 'release' label is present on the PR. When true, other trigger labels (breaking, feature, vuln) are ignored."
         required: false
@@ -118,7 +128,8 @@ jobs:
         id: push
         with:
           context: .
-          file: ./Dockerfile
+          file: ${{ inputs.image-dockerfile }}
+          build-args: ${{ inputs.image-build-args }}
           push: true
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:latest

--- a/docs/release-container.md
+++ b/docs/release-container.md
@@ -31,6 +31,15 @@ jobs:
       image-registry-username: ${{ github.actor }}
       # Comma-separated list of target platforms, default is linux/amd64,linux/arm64
       image-platforms: linux/amd64,linux/arm64
+      # Path to the Dockerfile, default is ./Dockerfile
+      image-dockerfile: ./Dockerfile
+      # Newline-separated Docker build arguments in KEY=VALUE form, passed
+      # to the Docker build via docker/build-push-action build-args.
+      # Default is none. Useful for baking build metadata into the image,
+      # e.g. the commit SHA. Do not use build args for secrets; they can be
+      # exposed in build logs and image history.
+      image-build-args: |
+        GIT_COMMIT=${{ github.sha }}
       # Publish the release after all jobs complete. Default is true.
       publish: true
       # Only release when the 'release' label is on the PR. Default is false.


### PR DESCRIPTION
Closes #186

## What/Why

The container release variants introduced in #180 hardcode `file: ./Dockerfile` and pass no build args, while `release.yaml` gained `image-dockerfile` and `image-build-args` inputs in #183. This adds the same optional inputs to `release-container.yaml` and `release-container-attest.yaml`, with defaults (`./Dockerfile`, empty) matching current behavior, so the change is additive and backward compatible for existing callers.

## Proof it works

actionlint passes on both modified workflows. The input definitions and `docker/build-push-action` wiring are copied verbatim from the merged `release.yaml` implementation, including the KEY=VALUE format wording and the do-not-pass-secrets caveat.

## Risk + AI role

low -- additive inputs with behavior-preserving defaults; no logic changes. AI-generated with human-directed design.

## Review focus

- Input descriptions and defaults staying in lockstep with `release.yaml`
- `docs/release-container.md` wording matching `docs/release.md`

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request