### PR TITLE
fix(ci): grant contents read to the auto-labeler job

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,11 +1,12 @@
 ---
 name: Lint GitHub Actions workflows
 on: [push, pull_request]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository to lint workflow files
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1

--- a/.github/workflows/auto-author-assign.yaml
+++ b/.github/workflows/auto-author-assign.yaml
@@ -7,13 +7,12 @@ name: "Auto Author Assign"
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   assign:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: write # Assign the PR author
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -9,16 +9,14 @@ on:
     secrets:
       github-token:
         required: true
-permissions:
-  contents: read
+permissions: {}
 jobs:
   main:
     permissions:
-      # Job-level permissions replace the workflow-level block, so contents
-      # must be repeated here: the autolabeler fetches the config file via the
-      # contents API, which fails on private repositories without it.
+      # The autolabeler fetches the config file via the contents API,
+      # which fails on private repositories without an explicit grant.
       contents: read
-      pull-requests: write
+      pull-requests: write # Apply labels to the pull request
     name: Auto label pull requests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   main:
     permissions:
+      # Job-level permissions replace the workflow-level block, so contents
+      # must be repeated here: the autolabeler fetches the config file via the
+      # contents API, which fails on private repositories without it.
+      contents: read
       pull-requests: write
     name: Auto label pull requests
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,13 +9,12 @@ on:
     secrets:
       github-token:
         required: true
-permissions:
-  contents: read
+permissions: {}
 jobs:
   labeler:
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # Read the labeler configuration
+      pull-requests: write # Apply labels to the pull request
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/mark-ready-when-ready.yml
+++ b/.github/workflows/mark-ready-when-ready.yml
@@ -10,8 +10,7 @@ on:
   pull_request_target:
     types: [opened, edited, labeled, unlabeled, synchronize]
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -22,10 +21,10 @@ jobs:
     name: Mark as ready after successful checks
     runs-on: ubuntu-latest
     permissions:
-      checks: read
-      contents: write
-      pull-requests: write
-      statuses: read
+      checks: read # Read check-run results
+      contents: write # Required by the mark-ready action to update the PR
+      pull-requests: write # Flip the PR out of draft
+      statuses: read # Read commit statuses
     if: |
       contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
       github.event.pull_request.draft == true

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -30,14 +30,13 @@ on:
     secrets:
       github-token:
         required: true
-permissions:
-  contents: read
+permissions: {}
 jobs:
   main:
     permissions:
-      contents: read
-      pull-requests: read
-      statuses: write
+      contents: read # Read the repository for the semantic check
+      pull-requests: read # Read the PR title
+      statuses: write # Report the validation status
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,14 +4,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "30 1 * * *" # https://crontab.guru/#30_1_*_*_* (everyday at 0130)
-permissions:
-  contents: read
+permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write # Mark and close stale issues
+      pull-requests: write # Mark and close stale pull requests
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1

--- a/.github/workflows/test-auto-labeler.yaml
+++ b/.github/workflows/test-auto-labeler.yaml
@@ -4,13 +4,12 @@ on:
   # pull_request_target event is required for autolabeler to support all PRs including forks
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   auto_labeler:
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # Read the release-drafter config
+      pull-requests: write # Apply labels to the pull request
     uses: ./.github/workflows/auto-labeler.yaml
     with:
       config-name: release-drafter.yaml

--- a/.github/workflows/test-labeler.yaml
+++ b/.github/workflows/test-labeler.yaml
@@ -4,13 +4,12 @@ on:
   # pull_request_target event is required for autolabeler to support all PRs including forks
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   labeler:
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # Read the labeler configuration
+      pull-requests: write # Apply labels to the pull request
     uses: ./.github/workflows/labeler.yaml
     with:
       config-path: .github/labeler.yml

--- a/.github/workflows/test-pr-title.yaml
+++ b/.github/workflows/test-pr-title.yaml
@@ -5,14 +5,13 @@ on:
   # pull_request_target event is required for autolabeler to support all PRs including forks
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
-permissions:
-  contents: read
+permissions: {}
 jobs:
   lint_pr_title:
     permissions:
-      contents: read
-      pull-requests: read
-      statuses: write
+      contents: read # Read the repository for the semantic check
+      pull-requests: read # Read the PR title
+      statuses: write # Report the validation status
     uses: ./.github/workflows/pr-title.yaml
     with:
       types: |


### PR DESCRIPTION
# Pull Request

## Proposed Changes

**Commit 1 — auto-labeler private-caller fix.** The auto-labeler reusable declared `contents: read` at the workflow level, but the `main` job overrides `permissions` with only `pull-requests: write`. Job-level permissions replace the workflow-level block rather than merging with it, so the job's token ends up with no contents access. The release-drafter autolabeler fetches its config file through the contents API — anonymous read succeeds on public repositories (which is why existing callers never hit this), but private callers fail with:

```
##[error]Repo load failed. Failed to fetch config from repo: Resource not accessible by integration
```

Not a recent regression: the job-level contents permission was removed in #38 (Jan 2025) when the workflow stopped creating releases, and has been latent in every tag since — only reachable by private callers.

**Commit 2 — deny-all permissions philosophy across all workflows.** The release-family workflows already use `permissions: {}` at the workflow level with explicit, commented job-level grants; the older files still relied on workflow-level `contents: read`, the exact foot-gun behind commit 1 (a job block silently discards it). Every workflow now declares `permissions: {}` at the top and each job grants exactly what it needs with a comment per permission. No job's effective permissions change except `actionlint`, whose implicit workflow-level grant moved into an explicit job-level one.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request (n/a: the documented caller examples already grant the required permissions; changes are internal to the workflows)