### PR TITLE
feat(ci)!: require issues:write in auto-labeler to auto-create missing labels

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -17,6 +17,7 @@ jobs:
       # which fails on private repositories without an explicit grant.
       contents: read
       pull-requests: write # Apply labels to the pull request
+      issues: write # Auto-create labels referenced in the autolabeler config but missing from the repository
     name: Auto label pull requests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-auto-labeler.yaml
+++ b/.github/workflows/test-auto-labeler.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read # Read the release-drafter config
       pull-requests: write # Apply labels to the pull request
+      issues: write # Auto-create labels referenced in the autolabeler config
     uses: ./.github/workflows/auto-labeler.yaml
     with:
       config-name: release-drafter.yaml

--- a/docs/auto-labeler.md
+++ b/docs/auto-labeler.md
@@ -5,8 +5,9 @@
 ```yaml
 - uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@main
   permissions:
-    contents: read
-    pull-requests: write
+    contents: read # Read the autolabeler config
+    pull-requests: write # Apply labels to the pull request
+    issues: write # Auto-create labels missing from the repository
   with:
     # The name of the configuration file to use, default is release-drafter.yml
     # from the release-drafter/release-drafter GitHub Action
@@ -19,3 +20,12 @@
 ## Outputs
 
 None
+
+## Missing labels
+
+If the autolabeler config references a label that does not exist in the repository, GitHub creates it automatically while applying it. This is why the workflow requires `issues: write`; the labels API is part of the Issues API.
+
+Auto-created labels get a default color and no description. If you care about label colors or descriptions, pre-create the labels (for example with the [Labeler workflow](labeler.md)) and the auto-labeler will use them as-is.
+
+> [!IMPORTANT]
+> `issues: write` became required in v2.0.0. Callers on v1 that upgrade must add it to their permissions block, or the workflow fails at startup with "The nested job 'main' is requesting 'issues: write', but is only allowed 'issues: none'".

--- a/docs/auto-labeler.md
+++ b/docs/auto-labeler.md
@@ -28,4 +28,4 @@ If the autolabeler config references a label that does not exist in the reposito
 Auto-created labels get a default color and no description. If you care about label colors or descriptions, pre-create the labels (for example with the [Labeler workflow](labeler.md)) and the auto-labeler will use them as-is.
 
 > [!IMPORTANT]
-> `issues: write` became required in v2.0.0. Callers on v1 that upgrade must add it to their permissions block, or the workflow fails at startup with "The nested job 'main' is requesting 'issues: write', but is only allowed 'issues: none'".
+> `issues: write` became required in v2.0.0. Callers referencing `@main` receive this change as soon as it merges and must add the grant to their permissions block immediately. Callers pinned to v1 must add it when they upgrade to v2. Without the grant the workflow fails at startup with "The nested job 'main' is requesting 'issues: write', but is only allowed 'issues: none'".


### PR DESCRIPTION
Closes #70

## What/Why

When the autolabeler config references a label that does not exist in the repository, the run fails with `HttpError: You do not have permission to create labels on this repository`. Label creation lives under the Issues API and needs `issues: write`, which the job did not request. This adds `issues: write` to the job so GitHub auto-creates missing labels while applying them, updates `test-auto-labeler.yaml` with the new grant, and documents the requirement plus the default-color caveat in `docs/auto-labeler.md`.

**Breaking**: callers must add `issues: write` to the permissions block of the job calling `auto-labeler.yaml`, or the workflow fails at startup with `The nested job 'main' is requesting 'issues: write', but is only allowed 'issues: none'`. Labeled `breaking` + `major` so this ships as v2.0.0 and `@v1` pinners are unaffected until they upgrade.

## Proof it works

- actionlint passes.
- End-to-end validation in a fork: a caller workflow pinned to this PR branch (`auto-labeler.yaml@feat/auto-labeler-issues-write`) granted `issues: write`, with an autolabeler config referencing `test-auto-create-70`, a label that did not exist in that repo. The run succeeded, created the label (default color, confirming the docs caveat), and applied it to the PR: https://github.com/jmeridth/ospo-reusable-workflows/actions/runs/32197000497. The same scenario without `issues: write` is the original failure linked in #70.
- Note: the auto-label check on this PR runs the base-branch (main) version of the workflow, since `pull_request_target` takes workflow files from the default branch, so it does not exercise this change. The fork run above is the actual integration test. `test-auto-labeler.yaml` carries the new grant so this repo's own runs keep working after merge.

## Risk + AI role

low -- one-line permission addition plus docs; autolabeler behavior is otherwise unchanged. AI-generated with human-directed design.

## Review focus

- Docs framing of the v2 upgrade path for existing callers

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
